### PR TITLE
feat(be): implement PM registry API with JWT auth and Solana address validation

### DIFF
--- a/be/package.json
+++ b/be/package.json
@@ -22,11 +22,15 @@
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/jwt": "^11.0.2",
+    "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^7.4.2",
     "@solana/web3.js": "^1.98.4",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "tweetnacl": "^1.0.3"
@@ -40,6 +44,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "dotenv": "^17.3.1",
     "eslint": "^9.18.0",

--- a/be/src/app.module.ts
+++ b/be/src/app.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaModule } from './prisma/prisma.module';
+import { AuthModule } from './auth/auth.module';
+import { RegistryModule } from './registry/registry.module';
 
 @Module({
-  imports: [],
+  imports: [PrismaModule, AuthModule, RegistryModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/be/src/auth/auth.controller.ts
+++ b/be/src/auth/auth.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { VerifySignatureDto } from './dto/verify-signature.dto';
+
+/**
+ * Controller for wallet-based authentication.
+ * This endpoint is public (no guards) — it issues JWT tokens
+ * after verifying a cryptographic wallet signature.
+ *
+ * @route /api/v1/auth
+ */
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * Verifies a wallet signature and returns a JWT access token.
+   *
+   * @param dto - The wallet address, message, and signature
+   * @returns JWT access token and user profile
+   */
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  async verify(@Body() dto: VerifySignatureDto) {
+    return this.authService.verifySignature(dto);
+  }
+}

--- a/be/src/auth/auth.module.ts
+++ b/be/src/auth/auth.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+/**
+ * Module responsible for wallet-based authentication and JWT token management.
+ * Imports PassportModule for strategy-based auth and JwtModule for token signing.
+ */
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET ?? 'default-secret',
+      signOptions: { expiresIn: '24h' },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/be/src/auth/auth.service.ts
+++ b/be/src/auth/auth.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PublicKey } from '@solana/web3.js';
+import nacl from 'tweetnacl';
+import { PrismaService } from '../prisma/prisma.service';
+import { VerifySignatureDto } from './dto/verify-signature.dto';
+
+/** Shape of the JWT payload stored in the token. */
+interface JwtPayload {
+  readonly sub: string;
+  readonly wallet_address: string;
+  readonly role: string;
+}
+
+/** Shape of the authentication response returned to the client. */
+export interface AuthResponse {
+  readonly access_token: string;
+  readonly user: {
+    readonly id: string;
+    readonly wallet_address: string;
+    readonly role: string;
+  };
+}
+
+/**
+ * Service responsible for wallet-based authentication.
+ * Verifies ed25519 signatures using tweetnacl and issues JWT tokens.
+ */
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  /**
+   * Verifies a wallet signature and returns a JWT access token.
+   *
+   * 1. Decodes the signature and public key from Base58
+   * 2. Verifies the ed25519 signature using tweetnacl
+   * 3. Looks up the user in the database by wallet address
+   * 4. Issues a JWT containing user ID, wallet address, and role
+   *
+   * @param dto - The verified signature payload
+   * @returns JWT access token and user profile
+   * @throws UnauthorizedException if signature is invalid or user not found
+   */
+  async verifySignature(dto: VerifySignatureDto): Promise<AuthResponse> {
+    const isValid = this.verifyEd25519Signature(
+      dto.message,
+      dto.signature,
+      dto.wallet_address,
+    );
+
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid wallet signature');
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { wallet_address: dto.wallet_address },
+      include: { role: true },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException(
+        'Wallet address is not registered in the system',
+      );
+    }
+
+    const payload: JwtPayload = {
+      sub: user.id,
+      wallet_address: user.wallet_address,
+      role: user.role.name,
+    };
+
+    const accessToken = this.jwtService.sign(payload);
+
+    return {
+      access_token: accessToken,
+      user: {
+        id: user.id,
+        wallet_address: user.wallet_address,
+        role: user.role.name,
+      },
+    };
+  }
+
+  /**
+   * Verifies an ed25519 signature using tweetnacl.
+   *
+   * @param message - The plaintext message that was signed
+   * @param signature - The Base58-encoded signature
+   * @param walletAddress - The Solana wallet address (public key)
+   * @returns true if the signature is valid, false otherwise
+   */
+  private verifyEd25519Signature(
+    message: string,
+    signature: string,
+    walletAddress: string,
+  ): boolean {
+    try {
+      const messageBytes = new TextEncoder().encode(message);
+      const publicKey = new PublicKey(walletAddress);
+      const publicKeyBytes = publicKey.toBytes();
+
+      // Decode Base58 signature using PublicKey utility for consistent decoding
+      const signatureBytes = Buffer.from(signature, 'base64');
+
+      return nacl.sign.detached.verify(
+        messageBytes,
+        signatureBytes,
+        publicKeyBytes,
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/be/src/auth/dto/verify-signature.dto.ts
+++ b/be/src/auth/dto/verify-signature.dto.ts
@@ -1,0 +1,23 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { IsSolanaAddress } from '../../common/validators/is-solana-address.validator';
+
+/**
+ * Data transfer object for wallet-based authentication.
+ * The frontend signs a plaintext message with the user's Solana wallet
+ * and submits the wallet address, message, and signature for verification.
+ */
+export class VerifySignatureDto {
+  /** The Solana wallet address (must be a valid 44-character Base58 public key). */
+  @IsSolanaAddress()
+  readonly wallet_address!: string;
+
+  /** The plaintext message that was signed by the wallet. */
+  @IsString()
+  @IsNotEmpty()
+  readonly message!: string;
+
+  /** The Base58-encoded ed25519 signature produced by the wallet. */
+  @IsString()
+  @IsNotEmpty()
+  readonly signature!: string;
+}

--- a/be/src/auth/strategies/jwt.strategy.ts
+++ b/be/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { RequestUser } from '../../common/interfaces/request-user.interface';
+
+/** Shape of the decoded JWT payload from the token. */
+interface JwtPayload {
+  readonly sub: string;
+  readonly wallet_address: string;
+  readonly role: string;
+}
+
+/**
+ * Passport strategy for validating JWT Bearer tokens.
+ * Extracts the token from the Authorization header, verifies it
+ * against the JWT_SECRET, and maps the payload to a RequestUser.
+ */
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET ?? 'default-secret',
+    });
+  }
+
+  /**
+   * Called by Passport after the JWT is verified.
+   * Maps the JWT payload to the RequestUser interface
+   * which gets attached to req.user.
+   *
+   * @param payload - The decoded JWT payload
+   * @returns The user object to attach to the request
+   */
+  validate(payload: JwtPayload): RequestUser {
+    return {
+      id: payload.sub,
+      walletAddress: payload.wallet_address,
+      role: payload.role,
+    };
+  }
+}

--- a/be/src/common/decorators/roles.decorator.ts
+++ b/be/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+
+/**
+ * Decorator that sets the required roles for accessing a route.
+ * Used in conjunction with RolesGuard to enforce RBAC.
+ *
+ * @param roles - One or more role names required for access (e.g., 'ADMIN', 'USER')
+ * @returns MethodDecorator & ClassDecorator
+ *
+ * @example
+ * \@Roles('ADMIN')
+ * \@Post()
+ * async createPM() { ... }
+ */
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/be/src/common/filters/prisma-exception.filter.ts
+++ b/be/src/common/filters/prisma-exception.filter.ts
@@ -1,0 +1,44 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { Response } from 'express';
+
+/**
+ * Exception filter that catches Prisma known request errors
+ * and converts them to appropriate HTTP responses.
+ *
+ * Handles P2002 (unique constraint violation) to enforce idempotency
+ * when duplicate wallet addresses or transaction signatures are submitted.
+ */
+@Catch(Prisma.PrismaClientKnownRequestError)
+export class PrismaClientExceptionFilter implements ExceptionFilter {
+  /** @inheritdoc */
+  catch(
+    exception: Prisma.PrismaClientKnownRequestError,
+    host: ArgumentsHost,
+  ): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    if (exception.code === 'P2002') {
+      const target = (exception.meta?.target as string[]) ?? ['unknown field'];
+
+      response.status(HttpStatus.CONFLICT).json({
+        statusCode: HttpStatus.CONFLICT,
+        message: `A record with this ${target.join(', ')} already exists`,
+        error: 'Conflict',
+      });
+      return;
+    }
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Internal server error',
+      error: 'Internal Server Error',
+    });
+  }
+}

--- a/be/src/common/guards/jwt-auth.guard.ts
+++ b/be/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * Guard that protects routes by requiring a valid JWT Bearer token.
+ * Delegates token extraction and validation to the Passport JwtStrategy.
+ * On success, attaches the decoded user payload to req.user.
+ */
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/be/src/common/guards/roles.guard.ts
+++ b/be/src/common/guards/roles.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { RequestUser } from '../interfaces/request-user.interface';
+
+/**
+ * Guard that enforces role-based access control (RBAC).
+ * Reads the required roles from @Roles() metadata and compares
+ * against the authenticated user's role on req.user.
+ *
+ * If no @Roles() decorator is present, access is granted.
+ * If the user's role is not in the required list, throws 403 Forbidden.
+ */
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  /** @inheritdoc */
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles) return true;
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const user = (request as Request & { user: RequestUser }).user;
+
+    if (!user) {
+      throw new ForbiddenException('No authenticated user found');
+    }
+
+    if (!requiredRoles.includes(user.role)) {
+      throw new ForbiddenException(
+        'You do not have permission to access this resource',
+      );
+    }
+
+    return true;
+  }
+}

--- a/be/src/common/interfaces/request-user.interface.ts
+++ b/be/src/common/interfaces/request-user.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents the authenticated user extracted from the JWT payload.
+ * Attached to the request object by JwtAuthGuard via Passport JwtStrategy.
+ */
+export interface RequestUser {
+  readonly id: string;
+  readonly walletAddress: string;
+  readonly role: string;
+}

--- a/be/src/common/validators/is-solana-address.validator.ts
+++ b/be/src/common/validators/is-solana-address.validator.ts
@@ -1,0 +1,55 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { PublicKey } from '@solana/web3.js';
+
+const SOLANA_ADDRESS_LENGTH = 44;
+
+/**
+ * Custom validator constraint that verifies a string is a valid Solana public key.
+ * Validates both string length (exactly 44 characters) and Base58 format
+ * by attempting to instantiate a PublicKey from @solana/web3.js.
+ */
+@ValidatorConstraint({ async: false })
+export class IsSolanaAddressConstraint implements ValidatorConstraintInterface {
+  /** @inheritdoc */
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    if (value.length !== SOLANA_ADDRESS_LENGTH) return false;
+
+    try {
+      new PublicKey(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** @inheritdoc */
+  defaultMessage(): string {
+    return 'Invalid Solana address format. Must be a 44-character public key.';
+  }
+}
+
+/**
+ * Decorator that validates a property is a valid Solana public key address.
+ *
+ * @param validationOptions - Optional class-validator options
+ * @returns PropertyDecorator
+ */
+export function IsSolanaAddress(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (target: object, propertyKey: string | symbol) {
+    registerDecorator({
+      target: target.constructor,
+      propertyName: String(propertyKey),
+      options: validationOptions,
+      constraints: [],
+      validator: IsSolanaAddressConstraint,
+    });
+  };
+}

--- a/be/src/main.ts
+++ b/be/src/main.ts
@@ -1,8 +1,23 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { PrismaClientExceptionFilter } from './common/filters/prisma-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.setGlobalPrefix('api/v1');
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  app.useGlobalFilters(new PrismaClientExceptionFilter());
+
   await app.listen(process.env.PORT ?? 3000);
 }
-bootstrap();
+void bootstrap();

--- a/be/src/prisma/prisma.module.ts
+++ b/be/src/prisma/prisma.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+/**
+ * Global module that provides PrismaService to the entire application.
+ * Marked as @Global() so other modules do not need to explicitly import it.
+ */
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/be/src/prisma/prisma.service.ts
+++ b/be/src/prisma/prisma.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * PrismaService provides database access throughout the application.
+ * Extends PrismaClient to inherit all generated query methods.
+ * Manages connection lifecycle via NestJS module hooks.
+ */
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  /** Connects to the database when the module initializes. */
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+  }
+
+  /** Disconnects from the database when the application shuts down. */
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+  }
+}

--- a/be/src/registry/dto/create-pm.dto.ts
+++ b/be/src/registry/dto/create-pm.dto.ts
@@ -1,0 +1,31 @@
+import { IsNotEmpty, IsNumber, IsString, IsUUID, Min } from 'class-validator';
+import { IsSolanaAddress } from '../../common/validators/is-solana-address.validator';
+
+/**
+ * Data transfer object for creating a new Project Manager registration.
+ * All fields are validated using class-validator decorators.
+ */
+export class CreatePMDto {
+  /** The display name of the project manager. */
+  @IsString()
+  @IsNotEmpty()
+  readonly name!: string;
+
+  /** The Solana wallet address (must be a valid 44-character Base58 public key). */
+  @IsSolanaAddress()
+  readonly wallet_address!: string;
+
+  /** The monthly target balance to maintain for this PM's wallet. Must be at least 1. */
+  @IsNumber()
+  @Min(1)
+  readonly target_balance!: number;
+
+  /** The project identifier this PM is assigned to. */
+  @IsString()
+  @IsNotEmpty()
+  readonly project_id!: string;
+
+  /** The UUID of the currency (e.g., USDC) for this PM's allocations. */
+  @IsUUID()
+  readonly currency_id!: string;
+}

--- a/be/src/registry/interfaces/registry-response.interface.ts
+++ b/be/src/registry/interfaces/registry-response.interface.ts
@@ -1,0 +1,28 @@
+/**
+ * Response payload for a successful PM creation.
+ */
+export interface CreatePMResponse {
+  readonly status: 'success';
+  readonly message: string;
+  readonly data: {
+    readonly id: string;
+    readonly is_active: boolean;
+  };
+}
+
+/**
+ * Shape of a PM record returned in the registry listing.
+ */
+export interface RegistryListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly wallet_address: string;
+  readonly target_balance: string;
+  readonly is_active: boolean;
+  readonly project_id: string;
+  readonly created_at: Date;
+  readonly currency: {
+    readonly id: string;
+    readonly symbol: string;
+  };
+}

--- a/be/src/registry/registry.controller.ts
+++ b/be/src/registry/registry.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { RegistryService } from './registry.service';
+import { CreatePMDto } from './dto/create-pm.dto';
+import {
+  CreatePMResponse,
+  RegistryListItem,
+} from './interfaces/registry-response.interface';
+
+/**
+ * Controller for the PM Registry API.
+ * All endpoints require ADMIN role authentication.
+ *
+ * @route /api/v1/registry
+ */
+@Controller('registry')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class RegistryController {
+  constructor(private readonly registryService: RegistryService) {}
+
+  /**
+   * Fetches all registered project managers.
+   *
+   * @returns Array of PM records with target_balance, is_active, and currency info
+   */
+  @Get()
+  async findAll(): Promise<RegistryListItem[]> {
+    return this.registryService.findAll();
+  }
+
+  /**
+   * Registers a new project manager.
+   *
+   * @param dto - The validated PM creation payload
+   * @returns Success response with created PM id and is_active status
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createPM(@Body() dto: CreatePMDto): Promise<CreatePMResponse> {
+    return this.registryService.createPM(dto);
+  }
+}

--- a/be/src/registry/registry.module.ts
+++ b/be/src/registry/registry.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { RegistryController } from './registry.controller';
+import { RegistryService } from './registry.service';
+
+/**
+ * Module encapsulating the PM Registry feature.
+ * PrismaService is available via the global PrismaModule.
+ */
+@Module({
+  controllers: [RegistryController],
+  providers: [RegistryService],
+  exports: [RegistryService],
+})
+export class RegistryModule {}

--- a/be/src/registry/registry.service.ts
+++ b/be/src/registry/registry.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePMDto } from './dto/create-pm.dto';
+import {
+  CreatePMResponse,
+  RegistryListItem,
+} from './interfaces/registry-response.interface';
+
+/**
+ * Service responsible for managing the Project Manager registry.
+ * Handles PM creation with automatic role assignment and listing.
+ */
+@Injectable()
+export class RegistryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Retrieves all registered project managers with their currency info.
+   *
+   * @returns Array of PM records including target_balance and is_active status
+   */
+  async findAll(): Promise<RegistryListItem[]> {
+    const users = await this.prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        wallet_address: true,
+        target_balance: true,
+        is_active: true,
+        project_id: true,
+        created_at: true,
+        currency: {
+          select: {
+            id: true,
+            symbol: true,
+          },
+        },
+      },
+    });
+
+    return users.map((user) => ({
+      ...user,
+      target_balance: user.target_balance.toString(),
+    }));
+  }
+
+  /**
+   * Creates a new Project Manager registration.
+   * Automatically assigns the 'USER' role from the Role table.
+   *
+   * @param dto - The validated PM creation payload
+   * @returns Success response with the new PM's id and is_active status
+   * @throws NotFoundException if the 'USER' role does not exist in the database
+   */
+  async createPM(dto: CreatePMDto): Promise<CreatePMResponse> {
+    const userRole = await this.prisma.role.findUnique({
+      where: { name: 'USER' },
+    });
+
+    if (!userRole) {
+      throw new NotFoundException(
+        'Role "USER" not found. Please seed the database with required roles.',
+      );
+    }
+
+    const user = await this.prisma.user.create({
+      data: {
+        name: dto.name,
+        wallet_address: dto.wallet_address,
+        target_balance: dto.target_balance,
+        project_id: dto.project_id,
+        currency_id: dto.currency_id,
+        role_id: userRole.id,
+      },
+      select: {
+        id: true,
+        is_active: true,
+      },
+    });
+
+    return {
+      status: 'success',
+      message: 'PM successfully registered.',
+      data: user,
+    };
+  }
+}

--- a/be/test/app.e2e-spec.ts
+++ b/be/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
@@ -13,12 +13,20 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it('/api/v1/ (GET)', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/api/v1/')
       .expect(200)
       .expect('Hello World!');
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@nestjs/core':
         specifier: ^11.0.1
         version: 11.1.15(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt':
+        specifier: ^11.0.2
+        version: 11.0.2(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/passport':
+        specifier: ^11.0.5
+        version: 11.0.5(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.15(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.15)
@@ -62,6 +68,12 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
+      passport:
+        specifier: ^0.7.0
+        version: 0.7.0
+      passport-jwt:
+        specifier: ^4.0.1
+        version: 4.0.1
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -96,6 +108,9 @@ importers:
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.13
+      '@types/passport-jwt':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
@@ -1166,6 +1181,17 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/jwt@11.0.2':
+    resolution: {integrity: sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
+  '@nestjs/passport@11.0.5':
+    resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      passport: ^0.5.0 || ^0.6.0 || ^0.7.0
 
   '@nestjs/platform-express@11.1.15':
     resolution: {integrity: sha512-sR42dQ5fPy4NGbnhT4mRIJLL0h2eNY4KpLkcfd27vg5XdTjQQ07wkQORrw6rAkWkBvMRr0dmhAcUBnXpe7ro5Q==}
@@ -2783,11 +2809,17 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mocha@9.1.1':
     resolution: {integrity: sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2797,6 +2829,15 @@ packages:
 
   '@types/node@24.11.0':
     resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
+
+  '@types/passport-jwt@4.0.1':
+    resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
+
+  '@types/passport-strategy@0.2.38':
+    resolution: {integrity: sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==}
+
+  '@types/passport@1.0.17':
+    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -5282,6 +5323,10 @@ packages:
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsqr@1.4.0:
     resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
 
@@ -5354,15 +5399,36 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
@@ -5840,6 +5906,17 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-jwt@4.0.1:
+    resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
+
+  passport-strategy@1.0.0:
+    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
+    engines: {node: '>= 0.4.0'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5875,6 +5952,9 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pause@0.0.1:
+    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -8236,7 +8316,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       jest-mock: 30.2.0
 
   '@jest/expect-utils@30.2.0':
@@ -8263,7 +8343,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.2.0
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
@@ -8582,6 +8662,17 @@ snapshots:
       uid: 2.0.2
     optionalDependencies:
       '@nestjs/platform-express': 11.1.15(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.15)
+
+  '@nestjs/jwt@11.0.2(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/jsonwebtoken': 9.0.10
+      jsonwebtoken: 9.0.3
+
+  '@nestjs/passport@11.0.5(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
+    dependencies:
+      '@nestjs/common': 11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      passport: 0.7.0
 
   '@nestjs/platform-express@11.1.15(@nestjs/common@11.1.15(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.15)':
     dependencies:
@@ -10959,9 +11050,16 @@ snapshots:
   '@types/json5@0.0.29':
     optional: true
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 24.11.0
+
   '@types/methods@1.1.4': {}
 
   '@types/mocha@9.1.1': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 
@@ -10972,6 +11070,20 @@ snapshots:
   '@types/node@24.11.0':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/passport-jwt@4.0.1':
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      '@types/passport-strategy': 0.2.38
+
+  '@types/passport-strategy@0.2.38':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/passport': 1.0.17
+
+  '@types/passport@1.0.17':
+    dependencies:
+      '@types/express': 5.0.6
 
   '@types/qs@6.14.0': {}
 
@@ -13945,7 +14057,7 @@ snapshots:
       '@jest/expect': 30.2.0
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -14050,7 +14162,7 @@ snapshots:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
@@ -14291,7 +14403,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14304,7 +14416,7 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 22.19.13
+      '@types/node': 24.11.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0
@@ -14387,6 +14499,19 @@ snapshots:
 
   jsonify@0.0.1: {}
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsqr@1.4.0: {}
 
   jwa@2.0.1:
@@ -14460,11 +14585,25 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
   lodash.isequal@4.5.0: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.throttle@4.1.1: {}
 
@@ -15063,6 +15202,19 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  passport-jwt@4.0.1:
+    dependencies:
+      jsonwebtoken: 9.0.3
+      passport-strategy: 1.0.0
+
+  passport-strategy@1.0.0: {}
+
+  passport@0.7.0:
+    dependencies:
+      passport-strategy: 1.0.0
+      pause: 0.0.1
+      utils-merge: 1.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -15088,6 +15240,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
+
+  pause@0.0.1: {}
 
   pbkdf2@3.1.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Add full wallet-based JWT authentication: `POST /api/v1/auth/verify` accepts `{ wallet_address, message, signature }`, verifies ed25519 signature via `tweetnacl`, looks up user + role in DB, issues JWT
- Implement Passport `JwtStrategy` for Bearer token validation on protected routes
- Add `@Roles()` decorator + `RolesGuard` for strict RBAC enforcement (ADMIN vs USER)
- Create `@IsSolanaAddress()` custom validator (44-char length + `PublicKey` construction check)
- Implement `RegistryModule` with `GET /api/v1/registry` (list PMs) and `POST /api/v1/registry` (create PM with auto USER role assignment)
- Add global `PrismaModule` with `PrismaService` extending `PrismaClient`
- Add `PrismaClientExceptionFilter` catching P2002 → 409 Conflict for idempotency
- Configure global `ValidationPipe` (whitelist, forbidNonWhitelisted, transform) and `/api/v1` prefix

## Test Plan

- [x] `pnpm --filter be build` compiles without errors
- [x] `pnpm --filter be lint` passes with 0 errors, 0 warnings
- [x] `pnpm --filter be test` — unit tests pass
- [ ] `POST /api/v1/auth/verify` with invalid signature → 401 Unauthorized
- [ ] `POST /api/v1/auth/verify` with valid signature → 200 with `access_token`
- [ ] `GET /api/v1/registry` without token → 401 Unauthorized
- [ ] `GET /api/v1/registry` with valid ADMIN token → 200 with array
- [ ] `POST /api/v1/registry` with USER token → 403 Forbidden
- [ ] `POST /api/v1/registry` with invalid Solana address → 400 Bad Request
- [ ] Duplicate `wallet_address` → 409 Conflict (P2002)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)