### PR TITLE
fix(fe,be): replace currency text input with dropdown from API

### DIFF
--- a/be/src/registry/interfaces/registry-response.interface.ts
+++ b/be/src/registry/interfaces/registry-response.interface.ts
@@ -26,3 +26,12 @@ export interface RegistryListItem {
     readonly symbol: string;
   };
 }
+
+/**
+ * Shape of a currency record returned in the currencies listing.
+ */
+export interface CurrencyListItem {
+  readonly id: string;
+  readonly symbol: string;
+  readonly decimals: number;
+}

--- a/be/src/registry/registry.controller.ts
+++ b/be/src/registry/registry.controller.ts
@@ -14,6 +14,7 @@ import { RegistryService } from './registry.service';
 import { CreatePMDto } from './dto/create-pm.dto';
 import {
   CreatePMResponse,
+  CurrencyListItem,
   RegistryListItem,
 } from './interfaces/registry-response.interface';
 
@@ -37,6 +38,16 @@ export class RegistryController {
   @Get()
   async findAll(): Promise<RegistryListItem[]> {
     return this.registryService.findAll();
+  }
+
+  /**
+   * Fetches all available currencies for PM allocation.
+   *
+   * @returns Array of currency records with id, symbol, and decimals
+   */
+  @Get('currencies')
+  async findAllCurrencies(): Promise<CurrencyListItem[]> {
+    return this.registryService.findAllCurrencies();
   }
 
   /**

--- a/be/src/registry/registry.service.ts
+++ b/be/src/registry/registry.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreatePMDto } from './dto/create-pm.dto';
 import {
   CreatePMResponse,
+  CurrencyListItem,
   RegistryListItem,
 } from './interfaces/registry-response.interface';
 
@@ -42,6 +43,21 @@ export class RegistryService {
       ...user,
       target_balance: user.target_balance.toString(),
     }));
+  }
+
+  /**
+   * Retrieves all available currencies for PM allocation.
+   *
+   * @returns Array of currency records with id, symbol, and decimals
+   */
+  async findAllCurrencies(): Promise<CurrencyListItem[]> {
+    return this.prisma.currency.findMany({
+      select: {
+        id: true,
+        symbol: true,
+        decimals: true,
+      },
+    });
   }
 
   /**

--- a/fe/src/api/registry.ts
+++ b/fe/src/api/registry.ts
@@ -1,4 +1,4 @@
-import type { PM, CreatePMPayload, CreatePMResponse } from '../types/registry';
+import type { PM, Currency, CreatePMPayload, CreatePMResponse } from '../types/registry';
 
 const API_BASE_URL = 'http://localhost:3000/api/v1';
 
@@ -21,6 +21,19 @@ export async function fetchRegistry(): Promise<PM[]> {
   }
 
   return response.json() as Promise<PM[]>;
+}
+
+/** Fetches all available currencies for PM allocation. */
+export async function fetchCurrencies(): Promise<Currency[]> {
+  const response = await fetch(`${API_BASE_URL}/registry/currencies`, {
+    headers: getAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch currencies: ${response.status}`);
+  }
+
+  return response.json() as Promise<Currency[]>;
 }
 
 /** Creates a new PM registration. */

--- a/fe/src/components/AddPMForm.tsx
+++ b/fe/src/components/AddPMForm.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import type { FormEvent } from 'react';
-import type { CreatePMPayload } from '../types/registry';
+import type { CreatePMPayload, Currency } from '../types/registry';
 
 interface AddPMFormProps {
   readonly onSubmit: (payload: CreatePMPayload) => Promise<unknown>;
   readonly isSubmitting: boolean;
+  readonly currencies: readonly Currency[];
 }
 
 interface FormFields {
@@ -53,13 +54,13 @@ function validate(fields: FormFields): FormErrors {
   }
 
   if (!fields.currency_id.trim()) {
-    errors.currency_id = 'Currency ID is required.';
+    errors.currency_id = 'Please select a currency.';
   }
 
   return errors;
 }
 
-export function AddPMForm({ onSubmit, isSubmitting }: AddPMFormProps) {
+export function AddPMForm({ onSubmit, isSubmitting, currencies }: AddPMFormProps) {
   const [fields, setFields] = useState<FormFields>(INITIAL_FIELDS);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -150,7 +151,42 @@ export function AddPMForm({ onSubmit, isSubmitting }: AddPMFormProps) {
       {renderField('wallet_address', 'Wallet Address')}
       {renderField('target_balance', 'Target Balance', 'number')}
       {renderField('project_id', 'Project ID')}
-      {renderField('currency_id', 'Currency ID')}
+
+      {(() => {
+        const error = touched['currency_id'] ? errors.currency_id : undefined;
+        const errorId = 'pm-currency_id-error';
+
+        return (
+          <div className="flex flex-col gap-1">
+            <label htmlFor="pm-currency_id" className="text-sm font-medium text-gray-700">
+              Currency
+            </label>
+            <select
+              id="pm-currency_id"
+              value={fields.currency_id}
+              onChange={(e) => handleChange('currency_id', e.target.value)}
+              onBlur={() => handleBlur('currency_id')}
+              aria-invalid={error ? 'true' : undefined}
+              aria-describedby={error ? errorId : undefined}
+              className={`rounded border px-3 py-2 text-sm outline-none transition-colors focus:ring-2 focus:ring-blue-500 ${
+                error ? 'border-red-500' : 'border-gray-300'
+              }`}
+            >
+              <option value="">Select a currency</option>
+              {currencies.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.symbol}
+                </option>
+              ))}
+            </select>
+            {error && (
+              <p id={errorId} className="text-xs text-red-600" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        );
+      })()}
 
       <button
         type="submit"

--- a/fe/src/components/PMRegistryPanel.tsx
+++ b/fe/src/components/PMRegistryPanel.tsx
@@ -3,7 +3,7 @@ import { PMTable } from './PMTable';
 import { AddPMForm } from './AddPMForm';
 
 export function PMRegistryPanel() {
-  const { pms, isLoading, error, addPM, isAdding } = useRegistryManager();
+  const { pms, isLoading, error, currencies, addPM, isAdding } = useRegistryManager();
 
   return (
     <div className="mx-auto max-w-5xl space-y-8 p-6">
@@ -25,7 +25,7 @@ export function PMRegistryPanel() {
 
       <div className="rounded border border-gray-200 bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-gray-800">Add Project Manager</h2>
-        <AddPMForm onSubmit={addPM} isSubmitting={isAdding} />
+        <AddPMForm onSubmit={addPM} isSubmitting={isAdding} currencies={currencies} />
       </div>
     </div>
   );

--- a/fe/src/hooks/useRegistryManager.ts
+++ b/fe/src/hooks/useRegistryManager.ts
@@ -1,8 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchRegistry, createPM } from '../api/registry';
+import { fetchRegistry, fetchCurrencies, createPM } from '../api/registry';
 import type { CreatePMPayload } from '../types/registry';
 
 const REGISTRY_KEY = ['registry'] as const;
+const CURRENCIES_KEY = ['currencies'] as const;
 
 /** Hook that provides registry data fetching and PM creation via TanStack Query. */
 export function useRegistryManager() {
@@ -11,6 +12,11 @@ export function useRegistryManager() {
   const registryQuery = useQuery({
     queryKey: REGISTRY_KEY,
     queryFn: fetchRegistry,
+  });
+
+  const currenciesQuery = useQuery({
+    queryKey: CURRENCIES_KEY,
+    queryFn: fetchCurrencies,
   });
 
   const addPMMutation = useMutation({
@@ -24,6 +30,7 @@ export function useRegistryManager() {
     pms: registryQuery.data ?? [],
     isLoading: registryQuery.isLoading,
     error: registryQuery.error,
+    currencies: currenciesQuery.data ?? [],
     addPM: addPMMutation.mutateAsync,
     isAdding: addPMMutation.isPending,
     addError: addPMMutation.error,

--- a/fe/src/types/registry.ts
+++ b/fe/src/types/registry.ts
@@ -13,6 +13,13 @@ export interface PM {
   };
 }
 
+/** Shape of a currency record returned by GET /api/v1/registry/currencies. */
+export interface Currency {
+  readonly id: string;
+  readonly symbol: string;
+  readonly decimals: number;
+}
+
 /** Payload sent to POST /api/v1/registry. */
 export interface CreatePMPayload {
   readonly name: string;


### PR DESCRIPTION
## Summary

- **BE**: Added `GET /api/v1/registry/currencies` endpoint returning available currencies (`id`, `symbol`, `decimals`)
- **FE**: Replaced the plain text `currency_id` input with a `<select>` dropdown populated from the new endpoint
- Fixes the 400 Bad Request error when creating a PM (the DTO validates `currency_id` as UUID, but the old text input accepted any string)

Closes #11

## Test plan

- [ ] Start BE + FE, log in as admin
- [ ] Verify the "Currency" field is now a dropdown with USDC and SOL options
- [ ] Fill form with valid data, select USDC, click Save → PM created (201)
- [ ] Verify new PM appears in the registry table

🤖 Generated with [Claude Code](https://claude.com/claude-code)