### PR TITLE
feat(be): replay protection tests and seed script

### DIFF
--- a/be/scripts/seed-transactions.ts
+++ b/be/scripts/seed-transactions.ts
@@ -1,0 +1,98 @@
+/**
+ * Seeds the database with 10,000 dummy transactions for performance testing.
+ *
+ * Usage: npx tsx be/scripts/seed-transactions.ts
+ *
+ * After running, verify index usage with:
+ *   EXPLAIN ANALYZE
+ *   SELECT * FROM "Transaction"
+ *   WHERE pm_id = '<uuid>'
+ *   ORDER BY block_time DESC
+ *   LIMIT 20;
+ */
+
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import pg from 'pg';
+
+const BATCH_SIZE = 500;
+const TOTAL_TRANSACTIONS = 10_000;
+const MERCHANTS = [
+  'AWS Services',
+  'Google Cloud',
+  'Hetzner',
+  'DigitalOcean',
+  'Vercel',
+  'GitHub',
+  'Figma',
+  'Notion',
+  'Slack',
+  'Linear',
+];
+
+async function main() {
+  const dbUrl = new URL(process.env.DATABASE_URL!);
+  const pool = new pg.Pool({
+    host: dbUrl.hostname,
+    port: Number(dbUrl.port) || 5432,
+    database: dbUrl.pathname.slice(1),
+    user: decodeURIComponent(dbUrl.username),
+    password: decodeURIComponent(dbUrl.password),
+  });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  await prisma.$connect();
+
+  const firstUser = await prisma.user.findFirst({ select: { id: true } });
+  if (!firstUser) {
+    console.error('No users found. Create at least one PM before seeding transactions.');
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  const firstCurrency = await prisma.currency.findFirst({ select: { id: true } });
+  if (!firstCurrency) {
+    console.error('No currencies found. Seed currencies before seeding transactions.');
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  const pmId = firstUser.id;
+  const currencyId = firstCurrency.id;
+  const now = Date.now();
+  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+
+  console.log(`Seeding ${TOTAL_TRANSACTIONS} transactions for PM ${pmId}...`);
+  const start = performance.now();
+
+  for (let batch = 0; batch < TOTAL_TRANSACTIONS / BATCH_SIZE; batch++) {
+    const records = Array.from({ length: BATCH_SIZE }, (_, i) => {
+      const idx = batch * BATCH_SIZE + i;
+      const blockTime = new Date(now - Math.random() * ninetyDaysMs);
+      return {
+        signature: `fake-sig-${idx}-${now}`,
+        type: Math.random() > 0.5 ? 'REFILL' as const : 'SPEND' as const,
+        merchant_name: MERCHANTS[idx % MERCHANTS.length],
+        amount: parseFloat((Math.random() * 500 + 1).toFixed(2)),
+        status: 'COMPLETED' as const,
+        block_time: blockTime,
+        pm_id: pmId,
+        currency_id: currencyId,
+      };
+    });
+
+    await prisma.transaction.createMany({ data: records });
+    console.log(`  Inserted batch ${batch + 1}/${TOTAL_TRANSACTIONS / BATCH_SIZE}`);
+  }
+
+  const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+  console.log(`Done. ${TOTAL_TRANSACTIONS} transactions seeded in ${elapsed}s.`);
+  console.log(`\nRun EXPLAIN ANALYZE to verify index usage:`);
+  console.log(`  SELECT * FROM "Transaction" WHERE pm_id = '${pmId}' ORDER BY block_time DESC LIMIT 20;`);
+
+  await prisma.$disconnect();
+}
+
+void main();

--- a/be/src/common/filters/prisma-exception.filter.spec.ts
+++ b/be/src/common/filters/prisma-exception.filter.spec.ts
@@ -1,0 +1,81 @@
+import { ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaClientExceptionFilter } from './prisma-exception.filter';
+
+describe('PrismaClientExceptionFilter', () => {
+  let filter: PrismaClientExceptionFilter;
+  let mockJson: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockHost: ArgumentsHost;
+
+  beforeEach(() => {
+    filter = new PrismaClientExceptionFilter();
+    mockJson = jest.fn();
+    mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+
+    mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status: mockStatus }),
+        getRequest: () => ({}),
+        getNext: () => jest.fn(),
+      }),
+      getArgs: () => [],
+      getArgByIndex: () => undefined,
+      switchToRpc: () => ({}) as ReturnType<ArgumentsHost['switchToRpc']>,
+      switchToWs: () => ({}) as ReturnType<ArgumentsHost['switchToWs']>,
+      getType: () => 'http' as const,
+    } satisfies ArgumentsHost;
+  });
+
+  it('should return 409 Conflict for P2002 (unique constraint violation)', () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed on the fields: (`signature`)',
+      {
+        code: 'P2002',
+        clientVersion: '7.0.0',
+        meta: { target: ['signature'] },
+      },
+    );
+
+    filter.catch(error, mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+    expect(mockJson).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: expect.stringContaining('signature') as string,
+      error: 'Conflict',
+    });
+  });
+
+  it('should default to "unknown field" when P2002 meta.target is missing', () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '7.0.0' },
+    );
+
+    filter.catch(error, mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+    expect(mockJson).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: expect.stringContaining('unknown field') as string,
+      error: 'Conflict',
+    });
+  });
+
+  it('should return 500 Internal Server Error for non-P2002 errors', () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      'Foreign key constraint failed',
+      { code: 'P2003', clientVersion: '7.0.0' },
+    );
+
+    filter.catch(error, mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mockJson).toHaveBeenCalledWith({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Internal server error',
+      error: 'Internal Server Error',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Unit tests** for `PrismaClientExceptionFilter` (3 test cases):
  - P2002 unique constraint → 409 Conflict with field name in message
  - P2002 with missing `meta.target` → fallback to "unknown field"
  - Non-P2002 Prisma error → 500 Internal Server Error
- **Seed script** (`be/scripts/seed-transactions.ts`): inserts 10,000 dummy transactions in batches of 500, spread over 90 days, for `EXPLAIN ANALYZE` performance verification of the `pm_id, block_time DESC` compound index

Note: Schema constraints (`@unique` on signature, `@@index` on pm_id+block_time), migration, and the exception filter itself were all implemented in the initial schema setup (TICKET-001). This PR adds the test coverage and performance tooling required by TICKET-005.

Closes #21

## Test plan
- [ ] `pnpm --filter be test` → 4 tests pass (3 new + 1 existing)
- [ ] `npx tsx be/scripts/seed-transactions.ts` → seeds 10k transactions
- [ ] `EXPLAIN ANALYZE SELECT * FROM "Transaction" WHERE pm_id = '<uuid>' ORDER BY block_time DESC LIMIT 20;` → uses index, < 50ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)