### PR TITLE
feat(be): real-time wallet monitor with Solana onLogs

### DIFF
--- a/be/src/app.module.ts
+++ b/be/src/app.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
+import { BlockchainModule } from './blockchain/blockchain.module';
+import { PrismaModule } from './prisma/prisma.module';
 import { RegistryModule } from './registry/registry.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, RegistryModule],
+  imports: [PrismaModule, AuthModule, RegistryModule, BlockchainModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/be/src/blockchain/blockchain.module.ts
+++ b/be/src/blockchain/blockchain.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+
+import { MetadataExtractorService } from './metadata-extractor.service';
+import { solanaConnectionProvider } from './solana-connection.provider';
+import { WalletMonitorService } from './wallet-monitor.service';
+
+/**
+ * Encapsulates all Solana blockchain interactions: RPC connection,
+ * WebSocket monitoring, and transaction metadata extraction.
+ */
+@Module({
+  providers: [
+    solanaConnectionProvider,
+    MetadataExtractorService,
+    WalletMonitorService,
+  ],
+  exports: [WalletMonitorService],
+})
+export class BlockchainModule {}

--- a/be/src/blockchain/metadata-extractor.service.ts
+++ b/be/src/blockchain/metadata-extractor.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Stub service for transaction metadata extraction.
+ * Full implementation deferred to TICKET-007.
+ */
+@Injectable()
+export class MetadataExtractorService {
+  private readonly logger = new Logger(MetadataExtractorService.name);
+
+  /**
+   * Processes a confirmed transaction signature.
+   * Currently a no-op stub that logs the signature.
+   *
+   * @param signature - The Solana transaction signature to process
+   */
+  processSignature(signature: string): void {
+    this.logger.log(`[STUB] Received signature for processing: ${signature}`);
+  }
+}

--- a/be/src/blockchain/solana-connection.provider.ts
+++ b/be/src/blockchain/solana-connection.provider.ts
@@ -1,0 +1,26 @@
+import type { Provider } from '@nestjs/common';
+import { Connection } from '@solana/web3.js';
+
+/** Injection token for the singleton Solana Connection instance. */
+export const SOLANA_CONNECTION = 'SOLANA_CONNECTION';
+
+const DEVNET_RPC_URL = 'https://api.devnet.solana.com';
+
+/**
+ * Factory provider that creates a singleton Solana Connection.
+ * Reads SOLANA_RPC_URL from environment; defaults to devnet.
+ * Uses 'confirmed' commitment for a balance of speed and finality.
+ * Optionally accepts SOLANA_WS_URL for a custom WebSocket endpoint.
+ */
+export const solanaConnectionProvider: Provider = {
+  provide: SOLANA_CONNECTION,
+  useFactory: (): Connection => {
+    const rpcUrl = process.env.SOLANA_RPC_URL ?? DEVNET_RPC_URL;
+    const wsUrl = process.env.SOLANA_WS_URL;
+
+    return new Connection(rpcUrl, {
+      commitment: 'confirmed',
+      wsEndpoint: wsUrl,
+    });
+  },
+};

--- a/be/src/blockchain/wallet-monitor.service.spec.ts
+++ b/be/src/blockchain/wallet-monitor.service.spec.ts
@@ -1,0 +1,170 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Connection } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { MetadataExtractorService } from './metadata-extractor.service';
+import { SOLANA_CONNECTION } from './solana-connection.provider';
+import { WalletMonitorService } from './wallet-monitor.service';
+
+/** Generate a valid base58-encoded Solana address from a deterministic seed byte. */
+const validAddress = (seed: number): string =>
+  new PublicKey(Buffer.alloc(32, seed)).toBase58();
+
+/**
+ * Unit tests for WalletMonitorService.
+ * Covers bootstrap, dynamic subscription, error filtering, and teardown.
+ */
+describe('WalletMonitorService', () => {
+  let service: WalletMonitorService;
+  let mockConnection: jest.Mocked<
+    Pick<Connection, 'onLogs' | 'removeOnLogsListener'>
+  >;
+  let mockPrisma: { user: { findMany: jest.Mock } };
+  let mockMetadataExtractor: jest.Mocked<MetadataExtractorService>;
+
+  beforeEach(async () => {
+    mockConnection = {
+      onLogs: jest.fn().mockReturnValue(1),
+      removeOnLogsListener: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockPrisma = {
+      user: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    mockMetadataExtractor = {
+      processSignature: jest.fn(),
+    } as unknown as jest.Mocked<MetadataExtractorService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletMonitorService,
+        { provide: SOLANA_CONNECTION, useValue: mockConnection },
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: MetadataExtractorService, useValue: mockMetadataExtractor },
+      ],
+    }).compile();
+
+    service = module.get<WalletMonitorService>(WalletMonitorService);
+  });
+
+  // ── Test Case 1: Service Bootstrapping ──────────────────────────────────
+  describe('onApplicationBootstrap', () => {
+    it('should subscribe to all active PM wallets from the database', async () => {
+      const wallets = [
+        { wallet_address: validAddress(1) },
+        { wallet_address: validAddress(2) },
+      ];
+      mockPrisma.user.findMany.mockResolvedValue(wallets);
+
+      // Return distinct subscription IDs
+      mockConnection.onLogs.mockReturnValueOnce(100).mockReturnValueOnce(101);
+
+      await service.onApplicationBootstrap();
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        select: { wallet_address: true },
+      });
+      expect(mockConnection.onLogs).toHaveBeenCalledTimes(2);
+      expect(service.subscriptionCount).toBe(2);
+    });
+  });
+
+  // ── Test Case 2: Dynamic Subscription ───────────────────────────────────
+  describe('subscribeToWallet', () => {
+    it('should create a new subscription and track it in the internal map', () => {
+      const address = validAddress(3);
+      mockConnection.onLogs.mockReturnValue(42);
+
+      service.subscribeToWallet(address);
+
+      expect(mockConnection.onLogs).toHaveBeenCalledTimes(1);
+
+      // Verify the first argument is a PublicKey matching the address
+
+      const calledPubKey: PublicKey = mockConnection.onLogs.mock.calls[0][0];
+      expect(calledPubKey.toBase58()).toBe(address);
+      expect(mockConnection.onLogs.mock.calls[0][2]).toBe('confirmed');
+
+      expect(service.subscriptionCount).toBe(1);
+    });
+
+    it('should be idempotent — skip if already subscribed', () => {
+      const address = validAddress(3);
+      mockConnection.onLogs.mockReturnValue(42);
+
+      service.subscribeToWallet(address);
+      service.subscribeToWallet(address);
+
+      expect(mockConnection.onLogs).toHaveBeenCalledTimes(1);
+      expect(service.subscriptionCount).toBe(1);
+    });
+  });
+
+  // ── Test Case 3: Error Filtering ────────────────────────────────────────
+  describe('handleLogs (via onLogs callback)', () => {
+    it('should drop failed transactions and not call processSignature', () => {
+      const address = validAddress(4);
+      mockConnection.onLogs.mockReturnValue(55);
+
+      service.subscribeToWallet(address);
+
+      // Extract the callback passed to onLogs
+      const callback = mockConnection.onLogs.mock.calls[0][1] as (logs: {
+        err: unknown;
+        signature: string;
+      }) => void;
+
+      // Simulate a failed on-chain transaction
+      callback({
+        err: { InstructionError: [0, 'Custom'] },
+        signature: 'failedSig123',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- Jest mock assertion requires unbound reference
+      expect(mockMetadataExtractor.processSignature).not.toHaveBeenCalled();
+    });
+
+    it('should forward successful transaction signatures to MetadataExtractorService', () => {
+      const address = validAddress(4);
+      mockConnection.onLogs.mockReturnValue(55);
+
+      service.subscribeToWallet(address);
+
+      const callback = mockConnection.onLogs.mock.calls[0][1] as (logs: {
+        err: unknown;
+        signature: string;
+      }) => void;
+
+      // Simulate a successful on-chain transaction
+      callback({ err: null, signature: 'successSig456' });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- Jest mock assertion requires unbound reference
+      expect(mockMetadataExtractor.processSignature).toHaveBeenCalledWith(
+        'successSig456',
+      );
+    });
+  });
+
+  // ── Test Case 4: Graceful Teardown ──────────────────────────────────────
+  describe('onModuleDestroy', () => {
+    it('should remove all listeners and clear the subscription map', async () => {
+      mockConnection.onLogs.mockReturnValueOnce(10).mockReturnValueOnce(20);
+
+      service.subscribeToWallet(validAddress(5));
+      service.subscribeToWallet(validAddress(6));
+      expect(service.subscriptionCount).toBe(2);
+
+      await service.onModuleDestroy();
+
+      expect(mockConnection.removeOnLogsListener).toHaveBeenCalledWith(10);
+      expect(mockConnection.removeOnLogsListener).toHaveBeenCalledWith(20);
+      expect(mockConnection.removeOnLogsListener).toHaveBeenCalledTimes(2);
+      expect(service.subscriptionCount).toBe(0);
+    });
+  });
+});

--- a/be/src/blockchain/wallet-monitor.service.ts
+++ b/be/src/blockchain/wallet-monitor.service.ts
@@ -1,0 +1,148 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { Connection, PublicKey } from '@solana/web3.js';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { MetadataExtractorService } from './metadata-extractor.service';
+import { SOLANA_CONNECTION } from './solana-connection.provider';
+
+/**
+ * Monitors active PM wallets via Solana WebSocket subscriptions (onLogs).
+ * Subscribes on bootstrap, supports dynamic add/remove, and tears down
+ * gracefully on module destroy.
+ */
+@Injectable()
+export class WalletMonitorService
+  implements OnApplicationBootstrap, OnModuleDestroy
+{
+  private readonly logger = new Logger(WalletMonitorService.name);
+
+  /** Maps wallet address → onLogs subscription ID. */
+  private readonly activeSubscriptions = new Map<string, number>();
+
+  constructor(
+    @Inject(SOLANA_CONNECTION) private readonly connection: Connection,
+    private readonly prisma: PrismaService,
+    private readonly metadataExtractor: MetadataExtractorService,
+  ) {}
+
+  /** Returns the number of active subscriptions. */
+  get subscriptionCount(): number {
+    return this.activeSubscriptions.size;
+  }
+
+  /**
+   * Lifecycle hook: bootstraps subscriptions for every active PM wallet
+   * stored in the database.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    const activeWallets = await this.prisma.user.findMany({
+      where: { is_active: true },
+      select: { wallet_address: true },
+    });
+
+    this.logger.log(
+      `Bootstrapping subscriptions for ${activeWallets.length} active wallet(s)`,
+    );
+
+    for (const { wallet_address } of activeWallets) {
+      this.subscribeToWallet(wallet_address);
+    }
+  }
+
+  /**
+   * Subscribes to on-chain log events for the given wallet address.
+   * Idempotent — silently skips if already subscribed.
+   *
+   * @param address - The Solana wallet address (base-58) to monitor
+   */
+  subscribeToWallet(address: string): void {
+    if (this.activeSubscriptions.has(address)) {
+      this.logger.debug(`Already subscribed to wallet ${address}, skipping`);
+      return;
+    }
+
+    const publicKey = new PublicKey(address);
+
+    const subId = this.connection.onLogs(
+      publicKey,
+      (logs) => this.handleLogs(address, logs),
+      'confirmed',
+    );
+
+    this.activeSubscriptions.set(address, subId);
+    this.logger.log(`Subscribed to wallet ${address} (subId=${subId})`);
+  }
+
+  /**
+   * Removes the WebSocket subscription for the given wallet address.
+   * No-op if the address is not currently subscribed.
+   *
+   * @param address - The Solana wallet address to stop monitoring
+   */
+  async unsubscribeFromWallet(address: string): Promise<void> {
+    const subId = this.activeSubscriptions.get(address);
+
+    if (subId === undefined) {
+      this.logger.debug(`No active subscription for wallet ${address}`);
+      return;
+    }
+
+    await this.connection.removeOnLogsListener(subId);
+    this.activeSubscriptions.delete(address);
+    this.logger.log(`Unsubscribed from wallet ${address} (subId=${subId})`);
+  }
+
+  /**
+   * Lifecycle hook: tears down all active subscriptions to prevent
+   * memory leaks on application shutdown.
+   */
+  async onModuleDestroy(): Promise<void> {
+    this.logger.log(
+      `Tearing down ${this.activeSubscriptions.size} subscription(s)`,
+    );
+
+    const teardownPromises: Promise<void>[] = [];
+
+    for (const [address, subId] of this.activeSubscriptions) {
+      teardownPromises.push(
+        this.connection.removeOnLogsListener(subId).then(() => {
+          this.logger.debug(`Removed listener for ${address} (subId=${subId})`);
+        }),
+      );
+    }
+
+    await Promise.all(teardownPromises);
+    this.activeSubscriptions.clear();
+  }
+
+  /**
+   * Internal handler invoked by each onLogs subscription.
+   * Drops failed transactions and forwards successful signatures
+   * to the MetadataExtractorService.
+   */
+  private handleLogs(
+    address: string,
+    logs: { err: unknown; signature: string },
+  ): void {
+    try {
+      if (logs.err !== null) {
+        this.logger.debug(
+          `Dropping failed tx ${logs.signature} for wallet ${address}`,
+        );
+        return;
+      }
+
+      this.metadataExtractor.processSignature(logs.signature);
+    } catch (error) {
+      // Background context — no HTTP exception filter.
+      // Log and continue to keep the subscription alive.
+      this.logger.error(`Error handling logs for wallet ${address}: ${error}`);
+    }
+  }
+}

--- a/be/src/registry/registry.module.ts
+++ b/be/src/registry/registry.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
+
+import { BlockchainModule } from '../blockchain/blockchain.module';
 import { RegistryController } from './registry.controller';
 import { RegistryService } from './registry.service';
 
 /**
  * Module encapsulating the PM Registry feature.
  * PrismaService is available via the global PrismaModule.
+ * Imports BlockchainModule for dynamic wallet monitoring on PM creation.
  */
 @Module({
+  imports: [BlockchainModule],
   controllers: [RegistryController],
   providers: [RegistryService],
   exports: [RegistryService],

--- a/be/src/registry/registry.service.ts
+++ b/be/src/registry/registry.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { WalletMonitorService } from '../blockchain/wallet-monitor.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePMDto } from './dto/create-pm.dto';
 import { UpdateTargetBalanceDto } from './dto/update-target-balance.dto';
@@ -13,10 +15,14 @@ import {
 /**
  * Service responsible for managing the Project Manager registry.
  * Handles PM creation with automatic role assignment and listing.
+ * Triggers real-time wallet monitoring on new PM creation.
  */
 @Injectable()
 export class RegistryService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly walletMonitor: WalletMonitorService,
+  ) {}
 
   /**
    * Retrieves all registered project managers with their currency info.
@@ -155,6 +161,9 @@ export class RegistryService {
         is_active: true,
       },
     });
+
+    // Start monitoring the new PM wallet immediately (fire-and-forget).
+    this.walletMonitor.subscribeToWallet(dto.wallet_address);
 
     return {
       status: 'success',


### PR DESCRIPTION
## Summary

- Add **BlockchainModule** with singleton Solana `Connection` provider, `WalletMonitorService`, and `MetadataExtractorService` stub
- Subscribe to on-chain log events (`connection.onLogs()`) for every active PM wallet on bootstrap
- Expose dynamic `subscribeToWallet()` / `unsubscribeFromWallet()` methods for runtime management
- Filter out failed transactions (`logs.err !== null`) and forward successful signatures to the metadata extractor
- Gracefully tear down all subscriptions on module destroy
- Wire `RegistryService.createPM()` to start monitoring new PM wallets immediately after creation

## Test plan

- [x] **Bootstrapping**: Verifies `onLogs` is called for each active wallet from DB on startup
- [x] **Dynamic subscription**: Verifies `subscribeToWallet()` creates subscription and is idempotent
- [x] **Error filtering**: Verifies failed tx are dropped, successful signatures forwarded
- [x] **Graceful teardown**: Verifies `removeOnLogsListener` called for all subs, map cleared
- [x] `pnpm --filter be lint` — 0 errors
- [x] `pnpm --filter be test` — 10/10 tests pass (6 new + 4 existing)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)